### PR TITLE
Add print stylesheets to restore accessibility

### DIFF
--- a/webicons.css
+++ b/webicons.css
@@ -34,6 +34,26 @@
   -webkit-border-radius: 6px;
   border-radius: 6px; }
 
+/* restore webicons accessibility for print */
+@media print {
+  * {
+      background: transparent !important;
+      color: #000 !important;
+      -moz-box-shadow: none !important;
+      -webkit-box-shadow: none !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+  }
+  .webicon {
+    text-indent: 0;
+    width: auto !important;
+    height: auto !important;
+    -moz-border-radius: 0 !important;
+    -webkit-border-radius: 0 !important;
+    border-radius: 0 !important;
+  }
+}
+
 .no-svg .webicon.f500px {
   background: url("webicons/webicon-f500px-m.png"); }
 

--- a/webicons.scss
+++ b/webicons.scss
@@ -5,6 +5,12 @@
 .webicon.small { width: 20px; height: 20px; -moz-border-radius: 3px; -webkit-border-radius: 3px; border-radius: 3px; }
 .webicon.large { width: 48px; height: 48px; -moz-border-radius: 6px; -webkit-border-radius: 6px; border-radius: 6px; }
 
+/* restore webicons accessibility for print */
+@media print {
+  * {background: transparent !important; color: #000 !important; -moz-box-shadow: none !important; -webkit-box-shadow: none !important; box-shadow: none !important; text-shadow: none !important;}
+  .webicon {text-indent: 0; width: auto !important; height: auto !important; -moz-border-radius: 0 !important; -webkit-border-radius: 0 !important; border-radius: 0 !important;}
+}
+
 // Include or remove the icons you want to use on your site from this list.
 $webicons-icons: f500px aboutme adn android apple behance bitbucket blogger branch coderwall creativecloud dribbble dropbox evernote fairheadcreative facebook flickr foursquare git github goodreads google googleplay googleplus hangouts html5 icloud indiegogo instagram instapaper kickstarter klout lastfm linkedin mail medium mixi msn openid picasa pinterest pocketapp potluck quora orkut mercurial rdio reddit renren rss skitch skype soundcloud spotify stackoverflow stumbleupon svn tent tripadvisor tumblr twitter vimeo weibo windows wordpress xing yahoo yelp youtube youversion zerply;
 


### PR DESCRIPTION
The CSS for icons has already been made with accessibility in mind as it uses the image replacement technique. All that's left to do is add some lines for `@media print` to flip back to text and remove unnecessary decorations.
