### PR TITLE
Use background-image longhand syntax for resizing purposes

### DIFF
--- a/webicons.css
+++ b/webicons.css
@@ -55,901 +55,901 @@
 }
 
 .no-svg .webicon.f500px {
-  background: url("webicons/webicon-f500px-m.png"); }
+  background-image: url("webicons/webicon-f500px-m.png"); }
 
 .no-svg .webicon.f500px.large {
-  background: url("webicons/webicon-f500px.png"); }
+  background-image: url("webicons/webicon-f500px.png"); }
 
 .no-svg .webicon.f500px.small {
-  background: url("webicons/webicon-f500px-s.png"); }
+  background-image: url("webicons/webicon-f500px-s.png"); }
 
 .svg .webicon.f500px {
-  background: url("webicons/webicon-f500px.svg"); }
+  background-image: url("webicons/webicon-f500px.svg"); }
 
 .no-svg .webicon.aboutme {
-  background: url("webicons/webicon-aboutme-m.png"); }
+  background-image: url("webicons/webicon-aboutme-m.png"); }
 
 .no-svg .webicon.aboutme.large {
-  background: url("webicons/webicon-aboutme.png"); }
+  background-image: url("webicons/webicon-aboutme.png"); }
 
 .no-svg .webicon.aboutme.small {
-  background: url("webicons/webicon-aboutme-s.png"); }
+  background-image: url("webicons/webicon-aboutme-s.png"); }
 
 .svg .webicon.aboutme {
-  background: url("webicons/webicon-aboutme.svg"); }
+  background-image: url("webicons/webicon-aboutme.svg"); }
 
 .no-svg .webicon.adn {
-  background: url("webicons/webicon-adn-m.png"); }
+  background-image: url("webicons/webicon-adn-m.png"); }
 
 .no-svg .webicon.adn.large {
-  background: url("webicons/webicon-adn.png"); }
+  background-image: url("webicons/webicon-adn.png"); }
 
 .no-svg .webicon.adn.small {
-  background: url("webicons/webicon-adn-s.png"); }
+  background-image: url("webicons/webicon-adn-s.png"); }
 
 .svg .webicon.adn {
-  background: url("webicons/webicon-adn.svg"); }
+  background-image: url("webicons/webicon-adn.svg"); }
 
 .no-svg .webicon.android {
-  background: url("webicons/webicon-android-m.png"); }
+  background-image: url("webicons/webicon-android-m.png"); }
 
 .no-svg .webicon.android.large {
-  background: url("webicons/webicon-android.png"); }
+  background-image: url("webicons/webicon-android.png"); }
 
 .no-svg .webicon.android.small {
-  background: url("webicons/webicon-android-s.png"); }
+  background-image: url("webicons/webicon-android-s.png"); }
 
 .svg .webicon.android {
-  background: url("webicons/webicon-android.svg"); }
+  background-image: url("webicons/webicon-android.svg"); }
 
 .no-svg .webicon.apple {
-  background: url("webicons/webicon-apple-m.png"); }
+  background-image: url("webicons/webicon-apple-m.png"); }
 
 .no-svg .webicon.apple.large {
-  background: url("webicons/webicon-apple.png"); }
+  background-image: url("webicons/webicon-apple.png"); }
 
 .no-svg .webicon.apple.small {
-  background: url("webicons/webicon-apple-s.png"); }
+  background-image: url("webicons/webicon-apple-s.png"); }
 
 .svg .webicon.apple {
-  background: url("webicons/webicon-apple.svg"); }
+  background-image: url("webicons/webicon-apple.svg"); }
 
 .no-svg .webicon.behance {
-  background: url("webicons/webicon-behance-m.png"); }
+  background-image: url("webicons/webicon-behance-m.png"); }
 
 .no-svg .webicon.behance.large {
-  background: url("webicons/webicon-behance.png"); }
+  background-image: url("webicons/webicon-behance.png"); }
 
 .no-svg .webicon.behance.small {
-  background: url("webicons/webicon-behance-s.png"); }
+  background-image: url("webicons/webicon-behance-s.png"); }
 
 .svg .webicon.behance {
-  background: url("webicons/webicon-behance.svg"); }
+  background-image: url("webicons/webicon-behance.svg"); }
 
 .no-svg .webicon.bitbucket {
-  background: url("webicons/webicon-bitbucket-m.png"); }
+  background-image: url("webicons/webicon-bitbucket-m.png"); }
 
 .no-svg .webicon.bitbucket.large {
-  background: url("webicons/webicon-bitbucket.png"); }
+  background-image: url("webicons/webicon-bitbucket.png"); }
 
 .no-svg .webicon.bitbucket.small {
-  background: url("webicons/webicon-bitbucket-s.png"); }
+  background-image: url("webicons/webicon-bitbucket-s.png"); }
 
 .svg .webicon.bitbucket {
-  background: url("webicons/webicon-bitbucket.svg"); }
+  background-image: url("webicons/webicon-bitbucket.svg"); }
 
 .no-svg .webicon.blogger {
-  background: url("webicons/webicon-blogger-m.png"); }
+  background-image: url("webicons/webicon-blogger-m.png"); }
 
 .no-svg .webicon.blogger.large {
-  background: url("webicons/webicon-blogger.png"); }
+  background-image: url("webicons/webicon-blogger.png"); }
 
 .no-svg .webicon.blogger.small {
-  background: url("webicons/webicon-blogger-s.png"); }
+  background-image: url("webicons/webicon-blogger-s.png"); }
 
 .svg .webicon.blogger {
-  background: url("webicons/webicon-blogger.svg"); }
+  background-image: url("webicons/webicon-blogger.svg"); }
 
 .no-svg .webicon.branch {
-  background: url("webicons/webicon-branch-m.png"); }
+  background-image: url("webicons/webicon-branch-m.png"); }
 
 .no-svg .webicon.branch.large {
-  background: url("webicons/webicon-branch.png"); }
+  background-image: url("webicons/webicon-branch.png"); }
 
 .no-svg .webicon.branch.small {
-  background: url("webicons/webicon-branch-s.png"); }
+  background-image: url("webicons/webicon-branch-s.png"); }
 
 .svg .webicon.branch {
-  background: url("webicons/webicon-branch.svg"); }
+  background-image: url("webicons/webicon-branch.svg"); }
 
 .no-svg .webicon.coderwall {
-  background: url("webicons/webicon-coderwall-m.png"); }
+  background-image: url("webicons/webicon-coderwall-m.png"); }
 
 .no-svg .webicon.coderwall.large {
-  background: url("webicons/webicon-coderwall.png"); }
+  background-image: url("webicons/webicon-coderwall.png"); }
 
 .no-svg .webicon.coderwall.small {
-  background: url("webicons/webicon-coderwall-s.png"); }
+  background-image: url("webicons/webicon-coderwall-s.png"); }
 
 .svg .webicon.coderwall {
-  background: url("webicons/webicon-coderwall.svg"); }
+  background-image: url("webicons/webicon-coderwall.svg"); }
 
 .no-svg .webicon.creativecloud {
-  background: url("webicons/webicon-creativecloud-m.png"); }
+  background-image: url("webicons/webicon-creativecloud-m.png"); }
 
 .no-svg .webicon.creativecloud.large {
-  background: url("webicons/webicon-creativecloud.png"); }
+  background-image: url("webicons/webicon-creativecloud.png"); }
 
 .no-svg .webicon.creativecloud.small {
-  background: url("webicons/webicon-creativecloud-s.png"); }
+  background-image: url("webicons/webicon-creativecloud-s.png"); }
 
 .svg .webicon.creativecloud {
-  background: url("webicons/webicon-creativecloud.svg"); }
+  background-image: url("webicons/webicon-creativecloud.svg"); }
 
 .no-svg .webicon.dribbble {
-  background: url("webicons/webicon-dribbble-m.png"); }
+  background-image: url("webicons/webicon-dribbble-m.png"); }
 
 .no-svg .webicon.dribbble.large {
-  background: url("webicons/webicon-dribbble.png"); }
+  background-image: url("webicons/webicon-dribbble.png"); }
 
 .no-svg .webicon.dribbble.small {
-  background: url("webicons/webicon-dribbble-s.png"); }
+  background-image: url("webicons/webicon-dribbble-s.png"); }
 
 .svg .webicon.dribbble {
-  background: url("webicons/webicon-dribbble.svg"); }
+  background-image: url("webicons/webicon-dribbble.svg"); }
 
 .no-svg .webicon.deviantart {
-  background: url("webicons/webicon-deviantart-m.png"); }
+  background-image: url("webicons/webicon-deviantart-m.png"); }
 
 .no-svg .webicon.deviantart.large {
-  background: url("webicons/webicon-deviantart.png"); }
+  background-image: url("webicons/webicon-deviantart.png"); }
 
 .no-svg .webicon.deviantart.small {
-  background: url("webicons/webicon-deviantart-s.png"); }
+  background-image: url("webicons/webicon-deviantart-s.png"); }
 
 .svg .webicon.deviantart {
-  background: url("webicons/webicon-deviantart.svg"); }
+  background-image: url("webicons/webicon-deviantart.svg"); }
 
 .no-svg .webicon.dropbox {
-  background: url("webicons/webicon-dropbox-m.png"); }
+  background-image: url("webicons/webicon-dropbox-m.png"); }
 
 .no-svg .webicon.dropbox.large {
-  background: url("webicons/webicon-dropbox.png"); }
+  background-image: url("webicons/webicon-dropbox.png"); }
 
 .no-svg .webicon.dropbox.small {
-  background: url("webicons/webicon-dropbox-s.png"); }
+  background-image: url("webicons/webicon-dropbox-s.png"); }
 
 .svg .webicon.dropbox {
-  background: url("webicons/webicon-dropbox.svg"); }
+  background-image: url("webicons/webicon-dropbox.svg"); }
 
 .no-svg .webicon.evernote {
-  background: url("webicons/webicon-evernote-m.png"); }
+  background-image: url("webicons/webicon-evernote-m.png"); }
 
 .no-svg .webicon.evernote.large {
-  background: url("webicons/webicon-evernote.png"); }
+  background-image: url("webicons/webicon-evernote.png"); }
 
 .no-svg .webicon.evernote.small {
-  background: url("webicons/webicon-evernote-s.png"); }
+  background-image: url("webicons/webicon-evernote-s.png"); }
 
 .svg .webicon.evernote {
-  background: url("webicons/webicon-evernote.svg"); }
+  background-image: url("webicons/webicon-evernote.svg"); }
 
 .no-svg .webicon.fairheadcreative {
-  background: url("webicons/webicon-fairheadcreative-m.png"); }
+  background-image: url("webicons/webicon-fairheadcreative-m.png"); }
 
 .no-svg .webicon.fairheadcreative.large {
-  background: url("webicons/webicon-fairheadcreative.png"); }
+  background-image: url("webicons/webicon-fairheadcreative.png"); }
 
 .no-svg .webicon.fairheadcreative.small {
-  background: url("webicons/webicon-fairheadcreative-s.png"); }
+  background-image: url("webicons/webicon-fairheadcreative-s.png"); }
 
 .svg .webicon.fairheadcreative {
-  background: url("webicons/webicon-fairheadcreative.svg"); }
+  background-image: url("webicons/webicon-fairheadcreative.svg"); }
 
 .no-svg .webicon.facebook {
-  background: url("webicons/webicon-facebook-m.png"); }
+  background-image: url("webicons/webicon-facebook-m.png"); }
 
 .no-svg .webicon.facebook.large {
-  background: url("webicons/webicon-facebook.png"); }
+  background-image: url("webicons/webicon-facebook.png"); }
 
 .no-svg .webicon.facebook.small {
-  background: url("webicons/webicon-facebook-s.png"); }
+  background-image: url("webicons/webicon-facebook-s.png"); }
 
 .svg .webicon.facebook {
-  background: url("webicons/webicon-facebook.svg"); }
+  background-image: url("webicons/webicon-facebook.svg"); }
 
 .no-svg .webicon.flickr {
-  background: url("webicons/webicon-flickr-m.png"); }
+  background-image: url("webicons/webicon-flickr-m.png"); }
 
 .no-svg .webicon.flickr.large {
-  background: url("webicons/webicon-flickr.png"); }
+  background-image: url("webicons/webicon-flickr.png"); }
 
 .no-svg .webicon.flickr.small {
-  background: url("webicons/webicon-flickr-s.png"); }
+  background-image: url("webicons/webicon-flickr-s.png"); }
 
 .svg .webicon.flickr {
-  background: url("webicons/webicon-flickr.svg"); }
+  background-image: url("webicons/webicon-flickr.svg"); }
 
 .no-svg .webicon.foursquare {
-  background: url("webicons/webicon-foursquare-m.png"); }
+  background-image: url("webicons/webicon-foursquare-m.png"); }
 
 .no-svg .webicon.foursquare.large {
-  background: url("webicons/webicon-foursquare.png"); }
+  background-image: url("webicons/webicon-foursquare.png"); }
 
 .no-svg .webicon.foursquare.small {
-  background: url("webicons/webicon-foursquare-s.png"); }
+  background-image: url("webicons/webicon-foursquare-s.png"); }
 
 .svg .webicon.foursquare {
-  background: url("webicons/webicon-foursquare.svg"); }
+  background-image: url("webicons/webicon-foursquare.svg"); }
 
 .no-svg .webicon.git {
-  background: url("webicons/webicon-git-m.png"); }
+  background-image: url("webicons/webicon-git-m.png"); }
 
 .no-svg .webicon.git.large {
-  background: url("webicons/webicon-git.png"); }
+  background-image: url("webicons/webicon-git.png"); }
 
 .no-svg .webicon.git.small {
-  background: url("webicons/webicon-git-s.png"); }
+  background-image: url("webicons/webicon-git-s.png"); }
 
 .svg .webicon.git {
-  background: url("webicons/webicon-git.svg"); }
+  background-image: url("webicons/webicon-git.svg"); }
 
 .no-svg .webicon.github {
-  background: url("webicons/webicon-github-m.png"); }
+  background-image: url("webicons/webicon-github-m.png"); }
 
 .no-svg .webicon.github.large {
-  background: url("webicons/webicon-github.png"); }
+  background-image: url("webicons/webicon-github.png"); }
 
 .no-svg .webicon.github.small {
-  background: url("webicons/webicon-github-s.png"); }
+  background-image: url("webicons/webicon-github-s.png"); }
 
 .svg .webicon.github {
-  background: url("webicons/webicon-github.svg"); }
+  background-image: url("webicons/webicon-github.svg"); }
 
 .no-svg .webicon.goodreads {
-  background: url("webicons/webicon-goodreads-m.png"); }
+  background-image: url("webicons/webicon-goodreads-m.png"); }
 
 .no-svg .webicon.goodreads.large {
-  background: url("webicons/webicon-goodreads.png"); }
+  background-image: url("webicons/webicon-goodreads.png"); }
 
 .no-svg .webicon.goodreads.small {
-  background: url("webicons/webicon-goodreads-s.png"); }
+  background-image: url("webicons/webicon-goodreads-s.png"); }
 
 .svg .webicon.goodreads {
-  background: url("webicons/webicon-goodreads.svg"); }
+  background-image: url("webicons/webicon-goodreads.svg"); }
 
 .no-svg .webicon.google {
-  background: url("webicons/webicon-google-m.png"); }
+  background-image: url("webicons/webicon-google-m.png"); }
 
 .no-svg .webicon.google.large {
-  background: url("webicons/webicon-google.png"); }
+  background-image: url("webicons/webicon-google.png"); }
 
 .no-svg .webicon.google.small {
-  background: url("webicons/webicon-google-s.png"); }
+  background-image: url("webicons/webicon-google-s.png"); }
 
 .svg .webicon.google {
-  background: url("webicons/webicon-google.svg"); }
+  background-image: url("webicons/webicon-google.svg"); }
 
 .no-svg .webicon.googleplay {
-  background: url("webicons/webicon-googleplay-m.png"); }
+  background-image: url("webicons/webicon-googleplay-m.png"); }
 
 .no-svg .webicon.googleplay.large {
-  background: url("webicons/webicon-googleplay.png"); }
+  background-image: url("webicons/webicon-googleplay.png"); }
 
 .no-svg .webicon.googleplay.small {
-  background: url("webicons/webicon-googleplay-s.png"); }
+  background-image: url("webicons/webicon-googleplay-s.png"); }
 
 .svg .webicon.googleplay {
-  background: url("webicons/webicon-googleplay.svg"); }
+  background-image: url("webicons/webicon-googleplay.svg"); }
 
 .no-svg .webicon.googleplus {
-  background: url("webicons/webicon-googleplus-m.png"); }
+  background-image: url("webicons/webicon-googleplus-m.png"); }
 
 .no-svg .webicon.googleplus.large {
-  background: url("webicons/webicon-googleplus.png"); }
+  background-image: url("webicons/webicon-googleplus.png"); }
 
 .no-svg .webicon.googleplus.small {
-  background: url("webicons/webicon-googleplus-s.png"); }
+  background-image: url("webicons/webicon-googleplus-s.png"); }
 
 .svg .webicon.googleplus {
-  background: url("webicons/webicon-googleplus.svg"); }
+  background-image: url("webicons/webicon-googleplus.svg"); }
 
 .no-svg .webicon.hangouts {
-  background: url("webicons/webicon-hangouts-m.png"); }
+  background-image: url("webicons/webicon-hangouts-m.png"); }
 
 .no-svg .webicon.hangouts.large {
-  background: url("webicons/webicon-hangouts.png"); }
+  background-image: url("webicons/webicon-hangouts.png"); }
 
 .no-svg .webicon.hangouts.small {
-  background: url("webicons/webicon-hangouts-s.png"); }
+  background-image: url("webicons/webicon-hangouts-s.png"); }
 
 .svg .webicon.hangouts {
-  background: url("webicons/webicon-hangouts.svg"); }
+  background-image: url("webicons/webicon-hangouts.svg"); }
 
 .no-svg .webicon.html5 {
-  background: url("webicons/webicon-html5-m.png"); }
+  background-image: url("webicons/webicon-html5-m.png"); }
 
 .no-svg .webicon.html5.large {
-  background: url("webicons/webicon-html5.png"); }
+  background-image: url("webicons/webicon-html5.png"); }
 
 .no-svg .webicon.html5.small {
-  background: url("webicons/webicon-html5-s.png"); }
+  background-image: url("webicons/webicon-html5-s.png"); }
 
 .svg .webicon.html5 {
-  background: url("webicons/webicon-html5.svg"); }
+  background-image: url("webicons/webicon-html5.svg"); }
 
 .no-svg .webicon.icloud {
-  background: url("webicons/webicon-icloud-m.png"); }
+  background-image: url("webicons/webicon-icloud-m.png"); }
 
 .no-svg .webicon.icloud.large {
-  background: url("webicons/webicon-icloud.png"); }
+  background-image: url("webicons/webicon-icloud.png"); }
 
 .no-svg .webicon.icloud.small {
-  background: url("webicons/webicon-icloud-s.png"); }
+  background-image: url("webicons/webicon-icloud-s.png"); }
 
 .svg .webicon.icloud {
-  background: url("webicons/webicon-icloud.svg"); }
+  background-image: url("webicons/webicon-icloud.svg"); }
 
 .no-svg .webicon.indiegogo {
-  background: url("webicons/webicon-indiegogo-m.png"); }
+  background-image: url("webicons/webicon-indiegogo-m.png"); }
 
 .no-svg .webicon.indiegogo.large {
-  background: url("webicons/webicon-indiegogo.png"); }
+  background-image: url("webicons/webicon-indiegogo.png"); }
 
 .no-svg .webicon.indiegogo.small {
-  background: url("webicons/webicon-indiegogo-s.png"); }
+  background-image: url("webicons/webicon-indiegogo-s.png"); }
 
 .svg .webicon.indiegogo {
-  background: url("webicons/webicon-indiegogo.svg"); }
+  background-image: url("webicons/webicon-indiegogo.svg"); }
 
 .no-svg .webicon.instagram {
-  background: url("webicons/webicon-instagram-m.png"); }
+  background-image: url("webicons/webicon-instagram-m.png"); }
 
 .no-svg .webicon.instagram.large {
-  background: url("webicons/webicon-instagram.png"); }
+  background-image: url("webicons/webicon-instagram.png"); }
 
 .no-svg .webicon.instagram.small {
-  background: url("webicons/webicon-instagram-s.png"); }
+  background-image: url("webicons/webicon-instagram-s.png"); }
 
 .svg .webicon.instagram {
-  background: url("webicons/webicon-instagram.svg"); }
+  background-image: url("webicons/webicon-instagram.svg"); }
 
 .no-svg .webicon.instapaper {
-  background: url("webicons/webicon-instapaper-m.png"); }
+  background-image: url("webicons/webicon-instapaper-m.png"); }
 
 .no-svg .webicon.instapaper.large {
-  background: url("webicons/webicon-instapaper.png"); }
+  background-image: url("webicons/webicon-instapaper.png"); }
 
 .no-svg .webicon.instapaper.small {
-  background: url("webicons/webicon-instapaper-s.png"); }
+  background-image: url("webicons/webicon-instapaper-s.png"); }
 
 .svg .webicon.instapaper {
-  background: url("webicons/webicon-instapaper.svg"); }
+  background-image: url("webicons/webicon-instapaper.svg"); }
 
 .no-svg .webicon.kickstarter {
-  background: url("webicons/webicon-kickstarter-m.png"); }
+  background-image: url("webicons/webicon-kickstarter-m.png"); }
 
 .no-svg .webicon.kickstarter.large {
-  background: url("webicons/webicon-kickstarter.png"); }
+  background-image: url("webicons/webicon-kickstarter.png"); }
 
 .no-svg .webicon.kickstarter.small {
-  background: url("webicons/webicon-kickstarter-s.png"); }
+  background-image: url("webicons/webicon-kickstarter-s.png"); }
 
 .svg .webicon.kickstarter {
-  background: url("webicons/webicon-kickstarter.svg"); }
+  background-image: url("webicons/webicon-kickstarter.svg"); }
 
 .no-svg .webicon.klout {
-  background: url("webicons/webicon-klout-m.png"); }
+  background-image: url("webicons/webicon-klout-m.png"); }
 
 .no-svg .webicon.klout.large {
-  background: url("webicons/webicon-klout.png"); }
+  background-image: url("webicons/webicon-klout.png"); }
 
 .no-svg .webicon.klout.small {
-  background: url("webicons/webicon-klout-s.png"); }
+  background-image: url("webicons/webicon-klout-s.png"); }
 
 .svg .webicon.klout {
-  background: url("webicons/webicon-klout.svg"); }
+  background-image: url("webicons/webicon-klout.svg"); }
 
 .no-svg .webicon.lastfm {
-  background: url("webicons/webicon-lastfm-m.png"); }
+  background-image: url("webicons/webicon-lastfm-m.png"); }
 
 .no-svg .webicon.lastfm.large {
-  background: url("webicons/webicon-lastfm.png"); }
+  background-image: url("webicons/webicon-lastfm.png"); }
 
 .no-svg .webicon.lastfm.small {
-  background: url("webicons/webicon-lastfm-s.png"); }
+  background-image: url("webicons/webicon-lastfm-s.png"); }
 
 .svg .webicon.lastfm {
-  background: url("webicons/webicon-lastfm.svg"); }
+  background-image: url("webicons/webicon-lastfm.svg"); }
 
 .no-svg .webicon.linkedin {
-  background: url("webicons/webicon-linkedin-m.png"); }
+  background-image: url("webicons/webicon-linkedin-m.png"); }
 
 .no-svg .webicon.linkedin.large {
-  background: url("webicons/webicon-linkedin.png"); }
+  background-image: url("webicons/webicon-linkedin.png"); }
 
 .no-svg .webicon.linkedin.small {
-  background: url("webicons/webicon-linkedin-s.png"); }
+  background-image: url("webicons/webicon-linkedin-s.png"); }
 
 .svg .webicon.linkedin {
-  background: url("webicons/webicon-linkedin.svg"); }
+  background-image: url("webicons/webicon-linkedin.svg"); }
 
 .no-svg .webicon.mail {
-  background: url("webicons/webicon-mail-m.png"); }
+  background-image: url("webicons/webicon-mail-m.png"); }
 
 .no-svg .webicon.mail.large {
-  background: url("webicons/webicon-mail.png"); }
+  background-image: url("webicons/webicon-mail.png"); }
 
 .no-svg .webicon.mail.small {
-  background: url("webicons/webicon-mail-s.png"); }
+  background-image: url("webicons/webicon-mail-s.png"); }
 
 .svg .webicon.mail {
-  background: url("webicons/webicon-mail.svg"); }
+  background-image: url("webicons/webicon-mail.svg"); }
 
 .no-svg .webicon.medium {
-  background: url("webicons/webicon-medium-m.png"); }
+  background-image: url("webicons/webicon-medium-m.png"); }
 
 .no-svg .webicon.medium.large {
-  background: url("webicons/webicon-medium.png"); }
+  background-image: url("webicons/webicon-medium.png"); }
 
 .no-svg .webicon.medium.small {
-  background: url("webicons/webicon-medium-s.png"); }
+  background-image: url("webicons/webicon-medium-s.png"); }
 
 .svg .webicon.medium {
-  background: url("webicons/webicon-medium.svg"); }
+  background-image: url("webicons/webicon-medium.svg"); }
 
 .no-svg .webicon.mixi {
-  background: url("webicons/webicon-mixi-m.png"); }
+  background-image: url("webicons/webicon-mixi-m.png"); }
 
 .no-svg .webicon.mixi.large {
-  background: url("webicons/webicon-mixi.png"); }
+  background-image: url("webicons/webicon-mixi.png"); }
 
 .no-svg .webicon.mixi.small {
-  background: url("webicons/webicon-mixi-s.png"); }
+  background-image: url("webicons/webicon-mixi-s.png"); }
 
 .svg .webicon.mixi {
-  background: url("webicons/webicon-mixi.svg"); }
+  background-image: url("webicons/webicon-mixi.svg"); }
 
 .no-svg .webicon.msn {
-  background: url("webicons/webicon-msn-m.png"); }
+  background-image: url("webicons/webicon-msn-m.png"); }
 
 .no-svg .webicon.msn.large {
-  background: url("webicons/webicon-msn.png"); }
+  background-image: url("webicons/webicon-msn.png"); }
 
 .no-svg .webicon.msn.small {
-  background: url("webicons/webicon-msn-s.png"); }
+  background-image: url("webicons/webicon-msn-s.png"); }
 
 .svg .webicon.msn {
-  background: url("webicons/webicon-msn.svg"); }
+  background-image: url("webicons/webicon-msn.svg"); }
 
 .no-svg .webicon.openid {
-  background: url("webicons/webicon-openid-m.png"); }
+  background-image: url("webicons/webicon-openid-m.png"); }
 
 .no-svg .webicon.openid.large {
-  background: url("webicons/webicon-openid.png"); }
+  background-image: url("webicons/webicon-openid.png"); }
 
 .no-svg .webicon.openid.small {
-  background: url("webicons/webicon-openid-s.png"); }
+  background-image: url("webicons/webicon-openid-s.png"); }
 
 .svg .webicon.openid {
-  background: url("webicons/webicon-openid.svg"); }
+  background-image: url("webicons/webicon-openid.svg"); }
 
 .no-svg .webicon.picasa {
-  background: url("webicons/webicon-picasa-m.png"); }
+  background-image: url("webicons/webicon-picasa-m.png"); }
 
 .no-svg .webicon.picasa.large {
-  background: url("webicons/webicon-picasa.png"); }
+  background-image: url("webicons/webicon-picasa.png"); }
 
 .no-svg .webicon.picasa.small {
-  background: url("webicons/webicon-picasa-s.png"); }
+  background-image: url("webicons/webicon-picasa-s.png"); }
 
 .svg .webicon.picasa {
-  background: url("webicons/webicon-picasa.svg"); }
+  background-image: url("webicons/webicon-picasa.svg"); }
 
 .no-svg .webicon.pinterest {
-  background: url("webicons/webicon-pinterest-m.png"); }
+  background-image: url("webicons/webicon-pinterest-m.png"); }
 
 .no-svg .webicon.pinterest.large {
-  background: url("webicons/webicon-pinterest.png"); }
+  background-image: url("webicons/webicon-pinterest.png"); }
 
 .no-svg .webicon.pinterest.small {
-  background: url("webicons/webicon-pinterest-s.png"); }
+  background-image: url("webicons/webicon-pinterest-s.png"); }
 
 .svg .webicon.pinterest {
-  background: url("webicons/webicon-pinterest.svg"); }
+  background-image: url("webicons/webicon-pinterest.svg"); }
 
 .no-svg .webicon.pocketapp {
-  background: url("webicons/webicon-pocketapp-m.png"); }
+  background-image: url("webicons/webicon-pocketapp-m.png"); }
 
 .no-svg .webicon.pocketapp.large {
-  background: url("webicons/webicon-pocketapp.png"); }
+  background-image: url("webicons/webicon-pocketapp.png"); }
 
 .no-svg .webicon.pocketapp.small {
-  background: url("webicons/webicon-pocketapp-s.png"); }
+  background-image: url("webicons/webicon-pocketapp-s.png"); }
 
 .svg .webicon.pocketapp {
-  background: url("webicons/webicon-pocketapp.svg"); }
+  background-image: url("webicons/webicon-pocketapp.svg"); }
 
 .no-svg .webicon.potluck {
-  background: url("webicons/webicon-potluck-m.png"); }
+  background-image: url("webicons/webicon-potluck-m.png"); }
 
 .no-svg .webicon.potluck.large {
-  background: url("webicons/webicon-potluck.png"); }
+  background-image: url("webicons/webicon-potluck.png"); }
 
 .no-svg .webicon.potluck.small {
-  background: url("webicons/webicon-potluck-s.png"); }
+  background-image: url("webicons/webicon-potluck-s.png"); }
 
 .svg .webicon.potluck {
-  background: url("webicons/webicon-potluck.svg"); }
+  background-image: url("webicons/webicon-potluck.svg"); }
 
 .no-svg .webicon.quora {
-  background: url("webicons/webicon-quora-m.png"); }
+  background-image: url("webicons/webicon-quora-m.png"); }
 
 .no-svg .webicon.quora.large {
-  background: url("webicons/webicon-quora.png"); }
+  background-image: url("webicons/webicon-quora.png"); }
 
 .no-svg .webicon.quora.small {
-  background: url("webicons/webicon-quora-s.png"); }
+  background-image: url("webicons/webicon-quora-s.png"); }
 
 .svg .webicon.quora {
-  background: url("webicons/webicon-quora.svg"); }
+  background-image: url("webicons/webicon-quora.svg"); }
 
 .no-svg .webicon.orkut {
-  background: url("webicons/webicon-orkut-m.png"); }
+  background-image: url("webicons/webicon-orkut-m.png"); }
 
 .no-svg .webicon.orkut.large {
-  background: url("webicons/webicon-orkut.png"); }
+  background-image: url("webicons/webicon-orkut.png"); }
 
 .no-svg .webicon.orkut.small {
-  background: url("webicons/webicon-orkut-s.png"); }
+  background-image: url("webicons/webicon-orkut-s.png"); }
 
 .svg .webicon.orkut {
-  background: url("webicons/webicon-orkut.svg"); }
+  background-image: url("webicons/webicon-orkut.svg"); }
 
 .no-svg .webicon.mercurial {
-  background: url("webicons/webicon-mercurial-m.png"); }
+  background-image: url("webicons/webicon-mercurial-m.png"); }
 
 .no-svg .webicon.mercurial.large {
-  background: url("webicons/webicon-mercurial.png"); }
+  background-image: url("webicons/webicon-mercurial.png"); }
 
 .no-svg .webicon.mercurial.small {
-  background: url("webicons/webicon-mercurial-s.png"); }
+  background-image: url("webicons/webicon-mercurial-s.png"); }
 
 .svg .webicon.mercurial {
-  background: url("webicons/webicon-mercurial.svg"); }
+  background-image: url("webicons/webicon-mercurial.svg"); }
 
 .no-svg .webicon.rdio {
-  background: url("webicons/webicon-rdio-m.png"); }
+  background-image: url("webicons/webicon-rdio-m.png"); }
 
 .no-svg .webicon.rdio.large {
-  background: url("webicons/webicon-rdio.png"); }
+  background-image: url("webicons/webicon-rdio.png"); }
 
 .no-svg .webicon.rdio.small {
-  background: url("webicons/webicon-rdio-s.png"); }
+  background-image: url("webicons/webicon-rdio-s.png"); }
 
 .svg .webicon.rdio {
-  background: url("webicons/webicon-rdio.svg"); }
+  background-image: url("webicons/webicon-rdio.svg"); }
 
 .no-svg .webicon.reddit {
-  background: url("webicons/webicon-reddit-m.png"); }
+  background-image: url("webicons/webicon-reddit-m.png"); }
 
 .no-svg .webicon.reddit.large {
-  background: url("webicons/webicon-reddit.png"); }
+  background-image: url("webicons/webicon-reddit.png"); }
 
 .no-svg .webicon.reddit.small {
-  background: url("webicons/webicon-reddit-s.png"); }
+  background-image: url("webicons/webicon-reddit-s.png"); }
 
 .svg .webicon.reddit {
-  background: url("webicons/webicon-reddit.svg"); }
+  background-image: url("webicons/webicon-reddit.svg"); }
 
 .no-svg .webicon.renren {
-  background: url("webicons/webicon-renren-m.png"); }
+  background-image: url("webicons/webicon-renren-m.png"); }
 
 .no-svg .webicon.renren.large {
-  background: url("webicons/webicon-renren.png"); }
+  background-image: url("webicons/webicon-renren.png"); }
 
 .no-svg .webicon.renren.small {
-  background: url("webicons/webicon-renren-s.png"); }
+  background-image: url("webicons/webicon-renren-s.png"); }
 
 .svg .webicon.renren {
-  background: url("webicons/webicon-renren.svg"); }
+  background-image: url("webicons/webicon-renren.svg"); }
 
 .no-svg .webicon.rss {
-  background: url("webicons/webicon-rss-m.png"); }
+  background-image: url("webicons/webicon-rss-m.png"); }
 
 .no-svg .webicon.rss.large {
-  background: url("webicons/webicon-rss.png"); }
+  background-image: url("webicons/webicon-rss.png"); }
 
 .no-svg .webicon.rss.small {
-  background: url("webicons/webicon-rss-s.png"); }
+  background-image: url("webicons/webicon-rss-s.png"); }
 
 .svg .webicon.rss {
-  background: url("webicons/webicon-rss.svg"); }
+  background-image: url("webicons/webicon-rss.svg"); }
 
 .no-svg .webicon.skitch {
-  background: url("webicons/webicon-skitch-m.png"); }
+  background-image: url("webicons/webicon-skitch-m.png"); }
 
 .no-svg .webicon.skitch.large {
-  background: url("webicons/webicon-skitch.png"); }
+  background-image: url("webicons/webicon-skitch.png"); }
 
 .no-svg .webicon.skitch.small {
-  background: url("webicons/webicon-skitch-s.png"); }
+  background-image: url("webicons/webicon-skitch-s.png"); }
 
 .svg .webicon.skitch {
-  background: url("webicons/webicon-skitch.svg"); }
+  background-image: url("webicons/webicon-skitch.svg"); }
 
 .no-svg .webicon.skype {
-  background: url("webicons/webicon-skype-m.png"); }
+  background-image: url("webicons/webicon-skype-m.png"); }
 
 .no-svg .webicon.skype.large {
-  background: url("webicons/webicon-skype.png"); }
+  background-image: url("webicons/webicon-skype.png"); }
 
 .no-svg .webicon.skype.small {
-  background: url("webicons/webicon-skype-s.png"); }
+  background-image: url("webicons/webicon-skype-s.png"); }
 
 .svg .webicon.skype {
-  background: url("webicons/webicon-skype.svg"); }
+  background-image: url("webicons/webicon-skype.svg"); }
 
 .no-svg .webicon.soundcloud {
-  background: url("webicons/webicon-soundcloud-m.png"); }
+  background-image: url("webicons/webicon-soundcloud-m.png"); }
 
 .no-svg .webicon.soundcloud.large {
-  background: url("webicons/webicon-soundcloud.png"); }
+  background-image: url("webicons/webicon-soundcloud.png"); }
 
 .no-svg .webicon.soundcloud.small {
-  background: url("webicons/webicon-soundcloud-s.png"); }
+  background-image: url("webicons/webicon-soundcloud-s.png"); }
 
 .svg .webicon.soundcloud {
-  background: url("webicons/webicon-soundcloud.svg"); }
+  background-image: url("webicons/webicon-soundcloud.svg"); }
 
 .no-svg .webicon.spotify {
-  background: url("webicons/webicon-spotify-m.png"); }
+  background-image: url("webicons/webicon-spotify-m.png"); }
 
 .no-svg .webicon.spotify.large {
-  background: url("webicons/webicon-spotify.png"); }
+  background-image: url("webicons/webicon-spotify.png"); }
 
 .no-svg .webicon.spotify.small {
-  background: url("webicons/webicon-spotify-s.png"); }
+  background-image: url("webicons/webicon-spotify-s.png"); }
 
 .svg .webicon.spotify {
-  background: url("webicons/webicon-spotify.svg"); }
+  background-image: url("webicons/webicon-spotify.svg"); }
 
 .no-svg .webicon.stackoverflow {
-  background: url("webicons/webicon-stackoverflow-m.png"); }
+  background-image: url("webicons/webicon-stackoverflow-m.png"); }
 
 .no-svg .webicon.stackoverflow.large {
-  background: url("webicons/webicon-stackoverflow.png"); }
+  background-image: url("webicons/webicon-stackoverflow.png"); }
 
 .no-svg .webicon.stackoverflow.small {
-  background: url("webicons/webicon-stackoverflow-s.png"); }
+  background-image: url("webicons/webicon-stackoverflow-s.png"); }
 
 .svg .webicon.stackoverflow {
-  background: url("webicons/webicon-stackoverflow.svg"); }
+  background-image: url("webicons/webicon-stackoverflow.svg"); }
 
 .no-svg .webicon.stumbleupon {
-  background: url("webicons/webicon-stumbleupon-m.png"); }
+  background-image: url("webicons/webicon-stumbleupon-m.png"); }
 
 .no-svg .webicon.stumbleupon.large {
-  background: url("webicons/webicon-stumbleupon.png"); }
+  background-image: url("webicons/webicon-stumbleupon.png"); }
 
 .no-svg .webicon.stumbleupon.small {
-  background: url("webicons/webicon-stumbleupon-s.png"); }
+  background-image: url("webicons/webicon-stumbleupon-s.png"); }
 
 .svg .webicon.stumbleupon {
-  background: url("webicons/webicon-stumbleupon.svg"); }
+  background-image: url("webicons/webicon-stumbleupon.svg"); }
 
 .no-svg .webicon.svtle {
-  background: url("webicons/webicon-svtle-m.png"); }
+  background-image: url("webicons/webicon-svtle-m.png"); }
 
 .no-svg .webicon.svtle.large {
-  background: url("webicons/webicon-svtle.png"); }
+  background-image: url("webicons/webicon-svtle.png"); }
 
 .no-svg .webicon.svtle.small {
-  background: url("webicons/webicon-svtle-s.png"); }
+  background-image: url("webicons/webicon-svtle-s.png"); }
 
 .svg .webicon.svtle {
-  background: url("webicons/webicon-svtle.svg"); }
+  background-image: url("webicons/webicon-svtle.svg"); }
 
 .no-svg .webicon.svn {
-  background: url("webicons/webicon-svn-m.png"); }
+  background-image: url("webicons/webicon-svn-m.png"); }
 
 .no-svg .webicon.svn.large {
-  background: url("webicons/webicon-svn.png"); }
+  background-image: url("webicons/webicon-svn.png"); }
 
 .no-svg .webicon.svn.small {
-  background: url("webicons/webicon-svn-s.png"); }
+  background-image: url("webicons/webicon-svn-s.png"); }
 
 .svg .webicon.svn {
-  background: url("webicons/webicon-svn.svg"); }
+  background-image: url("webicons/webicon-svn.svg"); }
 
 .no-svg .webicon.tent {
-  background: url("webicons/webicon-tent-m.png"); }
+  background-image: url("webicons/webicon-tent-m.png"); }
 
 .no-svg .webicon.tent.large {
-  background: url("webicons/webicon-tent.png"); }
+  background-image: url("webicons/webicon-tent.png"); }
 
 .no-svg .webicon.tent.small {
-  background: url("webicons/webicon-tent-s.png"); }
+  background-image: url("webicons/webicon-tent-s.png"); }
 
 .svg .webicon.tent {
-  background: url("webicons/webicon-tent.svg"); }
+  background-image: url("webicons/webicon-tent.svg"); }
 
 .no-svg .webicon.tripadvisor {
-  background: url("webicons/webicon-tripadvisor-m.png"); }
+  background-image: url("webicons/webicon-tripadvisor-m.png"); }
 
 .no-svg .webicon.tripadvisor.large {
-  background: url("webicons/webicon-tripadvisor.png"); }
+  background-image: url("webicons/webicon-tripadvisor.png"); }
 
 .no-svg .webicon.tripadvisor.small {
-  background: url("webicons/webicon-tripadvisor-s.png"); }
+  background-image: url("webicons/webicon-tripadvisor-s.png"); }
 
 .svg .webicon.tripadvisor {
-  background: url("webicons/webicon-tripadvisor.svg"); }
+  background-image: url("webicons/webicon-tripadvisor.svg"); }
 
 .no-svg .webicon.tumblr {
-  background: url("webicons/webicon-tumblr-m.png"); }
+  background-image: url("webicons/webicon-tumblr-m.png"); }
 
 .no-svg .webicon.tumblr.large {
-  background: url("webicons/webicon-tumblr.png"); }
+  background-image: url("webicons/webicon-tumblr.png"); }
 
 .no-svg .webicon.tumblr.small {
-  background: url("webicons/webicon-tumblr-s.png"); }
+  background-image: url("webicons/webicon-tumblr-s.png"); }
 
 .svg .webicon.tumblr {
-  background: url("webicons/webicon-tumblr.svg"); }
+  background-image: url("webicons/webicon-tumblr.svg"); }
 
 .no-svg .webicon.twitter {
-  background: url("webicons/webicon-twitter-m.png"); }
+  background-image: url("webicons/webicon-twitter-m.png"); }
 
 .no-svg .webicon.twitter.large {
-  background: url("webicons/webicon-twitter.png"); }
+  background-image: url("webicons/webicon-twitter.png"); }
 
 .no-svg .webicon.twitter.small {
-  background: url("webicons/webicon-twitter-s.png"); }
+  background-image: url("webicons/webicon-twitter-s.png"); }
 
 .svg .webicon.twitter {
-  background: url("webicons/webicon-twitter.svg"); }
+  background-image: url("webicons/webicon-twitter.svg"); }
 
 .no-svg .webicon.viadeo {
-  background: url("webicons/webicon-viadeo-m.png"); }
+  background-image: url("webicons/webicon-viadeo-m.png"); }
 
 .no-svg .webicon.viadeo.large {
-  background: url("webicons/webicon-viadeo.png"); }
+  background-image: url("webicons/webicon-viadeo.png"); }
 
 .no-svg .webicon.viadeo.small {
-  background: url("webicons/webicon-viadeo-s.png"); }
+  background-image: url("webicons/webicon-viadeo-s.png"); }
 
 .svg .webicon.viadeo {
-  background: url("webicons/webicon-viadeo.svg"); }
+  background-image: url("webicons/webicon-viadeo.svg"); }
 
 .no-svg .webicon.vine {
-  background: url("webicons/webicon-vine-m.png"); }
+  background-image: url("webicons/webicon-vine-m.png"); }
 
 .no-svg .webicon.vine.large {
-  background: url("webicons/webicon-vine.png"); }
+  background-image: url("webicons/webicon-vine.png"); }
 
 .no-svg .webicon.vine.small {
-  background: url("webicons/webicon-vine-s.png"); }
+  background-image: url("webicons/webicon-vine-s.png"); }
 
 .svg .webicon.vine {
-  background: url("webicons/webicon-vine.svg"); }
+  background-image: url("webicons/webicon-vine.svg"); }
 
 .no-svg .webicon.vimeo {
-  background: url("webicons/webicon-vimeo-m.png"); }
+  background-image: url("webicons/webicon-vimeo-m.png"); }
 
 .no-svg .webicon.vimeo.large {
-  background: url("webicons/webicon-vimeo.png"); }
+  background-image: url("webicons/webicon-vimeo.png"); }
 
 .no-svg .webicon.vimeo.small {
-  background: url("webicons/webicon-vimeo-s.png"); }
+  background-image: url("webicons/webicon-vimeo-s.png"); }
 
 .svg .webicon.vimeo {
-  background: url("webicons/webicon-vimeo.svg"); }
+  background-image: url("webicons/webicon-vimeo.svg"); }
 
 .no-svg .webicon.weibo {
-  background: url("webicons/webicon-weibo-m.png"); }
+  background-image: url("webicons/webicon-weibo-m.png"); }
 
 .no-svg .webicon.weibo.large {
-  background: url("webicons/webicon-weibo.png"); }
+  background-image: url("webicons/webicon-weibo.png"); }
 
 .no-svg .webicon.weibo.small {
-  background: url("webicons/webicon-weibo-s.png"); }
+  background-image: url("webicons/webicon-weibo-s.png"); }
 
 .svg .webicon.weibo {
-  background: url("webicons/webicon-weibo.svg"); }
+  background-image: url("webicons/webicon-weibo.svg"); }
 
 .no-svg .webicon.windows {
-  background: url("webicons/webicon-windows-m.png"); }
+  background-image: url("webicons/webicon-windows-m.png"); }
 
 .no-svg .webicon.windows.large {
-  background: url("webicons/webicon-windows.png"); }
+  background-image: url("webicons/webicon-windows.png"); }
 
 .no-svg .webicon.windows.small {
-  background: url("webicons/webicon-windows-s.png"); }
+  background-image: url("webicons/webicon-windows-s.png"); }
 
 .svg .webicon.windows {
-  background: url("webicons/webicon-windows.svg"); }
+  background-image: url("webicons/webicon-windows.svg"); }
 
 .no-svg .webicon.wordpress {
-  background: url("webicons/webicon-wordpress-m.png"); }
+  background-image: url("webicons/webicon-wordpress-m.png"); }
 
 .no-svg .webicon.wordpress.large {
-  background: url("webicons/webicon-wordpress.png"); }
+  background-image: url("webicons/webicon-wordpress.png"); }
 
 .no-svg .webicon.wordpress.small {
-  background: url("webicons/webicon-wordpress-s.png"); }
+  background-image: url("webicons/webicon-wordpress-s.png"); }
 
 .svg .webicon.wordpress {
-  background: url("webicons/webicon-wordpress.svg"); }
+  background-image: url("webicons/webicon-wordpress.svg"); }
 
 .no-svg .webicon.xing {
-  background: url("webicons/webicon-xing-m.png"); }
+  background-image: url("webicons/webicon-xing-m.png"); }
 
 .no-svg .webicon.xing.large {
-  background: url("webicons/webicon-xing.png"); }
+  background-image: url("webicons/webicon-xing.png"); }
 
 .no-svg .webicon.xing.small {
-  background: url("webicons/webicon-xing-s.png"); }
+  background-image: url("webicons/webicon-xing-s.png"); }
 
 .svg .webicon.xing {
-  background: url("webicons/webicon-xing.svg"); }
+  background-image: url("webicons/webicon-xing.svg"); }
 
 .no-svg .webicon.yahoo {
-  background: url("webicons/webicon-yahoo-m.png"); }
+  background-image: url("webicons/webicon-yahoo-m.png"); }
 
 .no-svg .webicon.yahoo.large {
-  background: url("webicons/webicon-yahoo.png"); }
+  background-image: url("webicons/webicon-yahoo.png"); }
 
 .no-svg .webicon.yahoo.small {
-  background: url("webicons/webicon-yahoo-s.png"); }
+  background-image: url("webicons/webicon-yahoo-s.png"); }
 
 .svg .webicon.yahoo {
-  background: url("webicons/webicon-yahoo.svg"); }
+  background-image: url("webicons/webicon-yahoo.svg"); }
 
 .no-svg .webicon.yelp {
-  background: url("webicons/webicon-yelp-m.png"); }
+  background-image: url("webicons/webicon-yelp-m.png"); }
 
 .no-svg .webicon.yelp.large {
-  background: url("webicons/webicon-yelp.png"); }
+  background-image: url("webicons/webicon-yelp.png"); }
 
 .no-svg .webicon.yelp.small {
-  background: url("webicons/webicon-yelp-s.png"); }
+  background-image: url("webicons/webicon-yelp-s.png"); }
 
 .svg .webicon.yelp {
-  background: url("webicons/webicon-yelp.svg"); }
+  background-image: url("webicons/webicon-yelp.svg"); }
 
 .no-svg .webicon.youtube {
-  background: url("webicons/webicon-youtube-m.png"); }
+  background-image: url("webicons/webicon-youtube-m.png"); }
 
 .no-svg .webicon.youtube.large {
-  background: url("webicons/webicon-youtube.png"); }
+  background-image: url("webicons/webicon-youtube.png"); }
 
 .no-svg .webicon.youtube.small {
-  background: url("webicons/webicon-youtube-s.png"); }
+  background-image: url("webicons/webicon-youtube-s.png"); }
 
 .svg .webicon.youtube {
-  background: url("webicons/webicon-youtube.svg"); }
+  background-image: url("webicons/webicon-youtube.svg"); }
 
 .no-svg .webicon.youversion {
-  background: url("webicons/webicon-youversion-m.png"); }
+  background-image: url("webicons/webicon-youversion-m.png"); }
 
 .no-svg .webicon.youversion.large {
-  background: url("webicons/webicon-youversion.png"); }
+  background-image: url("webicons/webicon-youversion.png"); }
 
 .no-svg .webicon.youversion.small {
-  background: url("webicons/webicon-youversion-s.png"); }
+  background-image: url("webicons/webicon-youversion-s.png"); }
 
 .svg .webicon.youversion {
-  background: url("webicons/webicon-youversion.svg"); }
+  background-image: url("webicons/webicon-youversion.svg"); }
 
 .no-svg .webicon.zerply {
-  background: url("webicons/webicon-zerply-m.png"); }
+  background-image: url("webicons/webicon-zerply-m.png"); }
 
 .no-svg .webicon.zerply.large {
-  background: url("webicons/webicon-zerply.png"); }
+  background-image: url("webicons/webicon-zerply.png"); }
 
 .no-svg .webicon.zerply.small {
-  background: url("webicons/webicon-zerply-s.png"); }
+  background-image: url("webicons/webicon-zerply-s.png"); }
 
 .svg .webicon.zerply {
-  background: url("webicons/webicon-zerply.svg"); }
+  background-image: url("webicons/webicon-zerply.svg"); }

--- a/webicons.less
+++ b/webicons.less
@@ -14,10 +14,10 @@
 .webicons-loop(@list, @index: 1) when (isstring(extract(@list, @index))) {
   @webicons-icon: extract(@list, @index);
   
-  .no-svg .webicon.@{webicons-icon}       { background: url("@{webicons-url}webicon-@{webicons-icon}-m.png"); }
-  .no-svg .webicon.@{webicons-icon}.large { background: url("@{webicons-url}webicon-@{webicons-icon}.png"); }
-  .no-svg .webicon.@{webicons-icon}.small { background: url("@{webicons-url}webicon-@{webicons-icon}-s.png"); }
-  .svg    .webicon.@{webicons-icon}       { background: url("@{webicons-url}webicon-@{webicons-icon}.svg"); }
+  .no-svg .webicon.@{webicons-icon}       { background-image: url("@{webicons-url}webicon-@{webicons-icon}-m.png"); }
+  .no-svg .webicon.@{webicons-icon}.large { background-image: url("@{webicons-url}webicon-@{webicons-icon}.png"); }
+  .no-svg .webicon.@{webicons-icon}.small { background-image: url("@{webicons-url}webicon-@{webicons-icon}-s.png"); }
+  .svg    .webicon.@{webicons-icon}       { background-image: url("@{webicons-url}webicon-@{webicons-icon}.svg"); }
 
   .webicons-loop(@list, (@index + 1));
 }

--- a/webicons.scss
+++ b/webicons.scss
@@ -18,8 +18,8 @@ $webicons-icons: f500px aboutme adn android apple behance bitbucket blogger bran
 $webicons-url: "webicons/" !default;
 
 @each $webicons-icon in $webicons-icons {
-  .no-svg .webicon.#{$webicons-icon}       { background: url("#{$webicons-url}webicon-#{$webicons-icon}-m.png"); }
-  .no-svg .webicon.#{$webicons-icon}.large { background: url("#{$webicons-url}webicon-#{$webicons-icon}.png"); }
-  .no-svg .webicon.#{$webicons-icon}.small { background: url("#{$webicons-url}webicon-#{$webicons-icon}-s.png"); }
-  .svg    .webicon.#{$webicons-icon}       { background: url("#{$webicons-url}webicon-#{$webicons-icon}.svg"); }
+  .no-svg .webicon.#{$webicons-icon}       { background-image: url("#{$webicons-url}webicon-#{$webicons-icon}-m.png"); }
+  .no-svg .webicon.#{$webicons-icon}.large { background-image: url("#{$webicons-url}webicon-#{$webicons-icon}.png"); }
+  .no-svg .webicon.#{$webicons-icon}.small { background-image: url("#{$webicons-url}webicon-#{$webicons-icon}-s.png"); }
+  .svg    .webicon.#{$webicons-icon}       { background-image: url("#{$webicons-url}webicon-#{$webicons-icon}.svg"); }
 }


### PR DESCRIPTION
Using the shorthand `background` attribute when setting the background image for each class overrides the `background-size:100%` value being set on `.webicon`. This means, when using dimensions other than 30x30px, the background doesn’t get resized to fit the container. Using `background-image` longhand style solves this.
